### PR TITLE
feat(sql): agregar campos password_hash y refresh_token a tabla users

### DIFF
--- a/sql/data.sql
+++ b/sql/data.sql
@@ -4,20 +4,20 @@ USE inventario_task_manager;
 -- ==========================================
 -- 1. POBLAR USERS
 -- ==========================================
-INSERT INTO users (id, name, email, document, role) VALUES
-(1, 'Juan Pérez', 'juan.perez@example.com', 1, 'user'),
-(2, 'María Gómez', 'maria.gomez@example.com', 2, 'user'),
-(3, 'Jhon Bueno', 'jhonbuenoa@example.com', 3, 'user'),
-(4, 'Ana Torres', 'ana.torres@example.com', 4, 'user'),
-(5, 'Nombre De Prueba Uno', 'luis.fernandez@example.com', 5, 'user'),
-(6, 'Sofía Martínez', 'sofia.martinez@example.com', 6, 'user'),
-(7, 'Pedro López', 'pedro.lopez@example.com', 7, 'user'),
-(8, 'Laura Castillo', 'laura.castillo@example.com', 8, 'user'),
-(9, 'Andrés Herrera', 'andres.herrera@example.com', 9, 'user'),
-(10, 'Valentina Ríos', 'valentina.rios@example.comm', 10, 'user'),
-(11, 'Admin Principal', 'admin.uno@example.com', 100, 'admin'),
-(12, 'Admin Secundario', 'admin.dos@example.com', 101, 'admin'),
-(13, 'Don Admin', 'donAdmin@example.com', 12, 'admin');
+INSERT INTO users (id, name, email, document, password_hash, role) VALUES -- Todas las password corresponden a "contraseña"
+(1, 'Jose Carlos', 'juan.perez@example.com', "10001", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(2, 'María Gómez', 'maria.gomez@example.com', "10002", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(3, 'Jhon Bueno', 'jhonbuenoa@example.com', "10003", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(4, 'Ana Torres', 'ana.torres@example.com', "10004", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(5, 'Nombre De Prueba Uno', 'luis.fernandez@example.com', "10005", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(6, 'Sofía Martínez', 'sofia.martinez@example.com', "10006", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(7, 'Pedro López', 'pedro.lopez@example.com', "10007", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(8, 'Laura Castillo', 'laura.castillo@example.com', "10008", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(9, 'Andrés Herrera', 'andres.herrera@example.com', "10009", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(10, 'Valentina Ríos', 'valentina.rios@example.comm', "10010", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'user'),
+(11, 'Admin Principal', 'admin.uno@example.com', "10011", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'admin'),
+(12, 'Admin Secundario', 'admin.dos@example.com', "10012", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'admin'),
+(13, 'Don Admin', 'donAdmin@example.com', "10013", "$2b$10$WfvS1ezsrgtfAIa2mOyWquOq1Q.MouisXVN7rFg6E.ZhnE960qwJy", 'admin');
 
 -- ==========================================
 -- 2. POBLAR TASKS

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -29,6 +29,8 @@ CREATE TABLE users (
     name VARCHAR(100) NOT NULL,
     email VARCHAR(100) NOT NULL,
     document VARCHAR(20) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    refresh_token VARCHAR (500) NULL,
     role ENUM('admin', 'user') DEFAULT 'user',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP


### PR DESCRIPTION
## Descripción del Cambio

Se modifica el esquema de base de datos en `src/sql/database.sql` para soportar la autenticación JWT. Se añaden las columnas `password_hash` (VARCHAR(255) NOT NULL) y `refresh_token` (VARCHAR(500) NULL) a la tabla `users`. Adicionalmente, se actualiza `src/sql/data.sql` para poblar los registros de prueba con un hash bcrypt correspondiente a la palabra "contraseña", documentado mediante comentario SQL. Las demás tablas y relaciones permanecen intactas.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [ ] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #43 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** He actualizado mi rama con `origin/develop` y resolví conflictos.
- [x] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.